### PR TITLE
update to the latest options of ideviceinstaller

### DIFF
--- a/main.js
+++ b/main.js
@@ -45,7 +45,7 @@ IDevice.prototype._build_cmd = function (options) {
     cmd += this.cmd;
 
     if (this.uuid) {
-	cmd += " -U " + this.udid;
+	cmd += " -u " + this.udid;
     }
 
     if (typeof options == 'object' && options.indexOf) {
@@ -121,7 +121,7 @@ IDevice.prototype.listAll = function (cb) {
 };
 
 IDevice.prototype.remove = function (app, cb) {
-    exec(this._build_cmd(['-u', app]), function (err, stdout, stderr) {
+    exec(this._build_cmd(['-U', app]), function (err, stdout, stderr) {
 	if (err) {
 	    cb(err, stdout);
 	} else {


### PR DESCRIPTION
update to the latest options of ideviceinstaller

```bash
➜  node-idevice git:(master) ideviceinstaller
ERROR: No mode/operation was supplied.
Usage: ideviceinstaller OPTIONS
Manage apps on iOS devices.

  -u, --udid UDID	Target specific device by its 40-digit device UDID.
  -l, --list-apps	List apps, possible options:
       -o list_user	- list user apps only (this is the default)
       -o list_system	- list system apps only
       -o list_all	- list all types of apps
       -o xml		- print full output as xml plist
  -i, --install ARCHIVE	Install app from package file specified by ARCHIVE.
                       	ARCHIVE can also be a .ipcc file for carrier bundles.
  -U, --uninstall APPID	Uninstall app specified by APPID.
  -g, --upgrade ARCHIVE	Upgrade app from package file specified by ARCHIVE.
  -L, --list-archives	List archived applications, possible options:
       -o xml		- print full output as xml plist
  -a, --archive APPID	Archive app specified by APPID, possible options:
       -o uninstall	- uninstall the package after making an archive
       -o app_only	- archive application data only
       -o docs_only	- archive documents (user data) only
       -o copy=PATH	- copy the app archive to directory PATH when done
       -o remove	- only valid when copy=PATH is used: remove after copy
  -r, --restore APPID	Restore archived app specified by APPID
  -R, --remove-archive APPID  Remove app archive specified by APPID
  -o, --options		Pass additional options to the specified command.
  -h, --help		prints usage information
  -d, --debug		enable communication debugging

```